### PR TITLE
feat!: scrollCacheExtent migration and Flutter 3.44 support (v2.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.9.0
+
+* Require Flutter 3.44.0 (Dart 3.12.0) or later.
+* **BREAKING**: Replace the `cacheExtent` (`double?`) parameter with `scrollCacheExtent` (`ScrollCacheExtent?`) in `PagingList`, `PagingGrid`, `GroupedPagingList`, `GroupedPagingGrid`, and `CenterPagingList`, following Flutter's deprecation of `ScrollView.cacheExtent`. Migrate `cacheExtent: 250` to `scrollCacheExtent: ScrollCacheExtent.pixels(250)`.
+
 ## 2.8.1
 
 * Prevent duplicate load requests while a load is already in progress in `DataSource` and `CenterDataSource`.

--- a/README.md
+++ b/README.md
@@ -262,10 +262,12 @@ class _PagingGridDemoState extends State<PagingGridDemo> {
 
 Since `paging_view` is built on top of Slivers, integrating with `CustomScrollView` is seamless. This is perfect for screens with collapsible headers or other complex scroll effects.
 
-A key aspect of this integration is the `CustomScrollView`'s `cacheExtent` property. By adjusting `cacheExtent`, you can control how far in advance (or behind) `paging_view` requests new data for `append` and `prepend` operations. A larger `cacheExtent` will trigger data loading earlier, providing a smoother user experience, especially during fast scrolling.
+A key aspect of this integration is the `CustomScrollView`'s `scrollCacheExtent` property. By adjusting `scrollCacheExtent`, you can control how far in advance (or behind) `paging_view` requests new data for `append` and `prepend` operations. A larger `scrollCacheExtent` will trigger data loading earlier, providing a smoother user experience, especially during fast scrolling.
 
 ```dart
 CustomScrollView(
+  // Load further ahead/behind so paging requests fire earlier.
+  scrollCacheExtent: const ScrollCacheExtent.pixels(500),
   slivers: [
     const SliverAppBar(
       title: Text('Sliver Example'),
@@ -590,7 +592,7 @@ class _CenterPagingListDemoState extends State<CenterPagingListDemo> {
 
 ## Further Reading
 
-* [Paging and Flutter (and the paging_view package)](https://zenn.dev/koji_1009/articles/5d34da19bc802e?locale=en) — Design philosophy behind `paging_view`, including how `SliverBoundsDetector` and `cacheExtent` interact to enable smooth infinite scrolling.
+* [Paging and Flutter (and the paging_view package)](https://zenn.dev/koji_1009/articles/5d34da19bc802e?locale=en) — Design philosophy behind `paging_view`, including how `SliverBoundsDetector` and `scrollCacheExtent` interact to enable smooth infinite scrolling.
 
 ## API Reference
 

--- a/lib/src/widget/center_paging_list.dart
+++ b/lib/src/widget/center_paging_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/widgets.dart';
 import 'package:paging_view/src/center_data_source.dart';
 import 'package:paging_view/src/function.dart';
@@ -40,7 +41,7 @@ class CenterPagingList<PageKey, Value> extends StatelessWidget {
     this.physics,
     this.scrollBehavior,
     this.shrinkWrap = false,
-    this.cacheExtent,
+    this.scrollCacheExtent,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.clipBehavior = Clip.hardEdge,
@@ -66,11 +67,12 @@ class CenterPagingList<PageKey, Value> extends StatelessWidget {
     this.physics,
     this.scrollBehavior,
     this.shrinkWrap = false,
-    this.cacheExtent,
+    this.scrollCacheExtent,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.clipBehavior = Clip.hardEdge,
     required IndexedWidgetBuilder separatorBuilder,
+    // ignore: prefer_initializing_formals
   }) : _separatorBuilder = separatorBuilder;
 
   /// The [CenterDataSource] that provides the paginated data.
@@ -140,9 +142,10 @@ class CenterPagingList<PageKey, Value> extends StatelessWidget {
   /// determined by the contents being viewed.
   final bool shrinkWrap;
 
-  /// The viewport has an area before and after the visible area to cache items
-  /// that are about to become visible when the user scrolls.
-  final double? cacheExtent;
+  /// The cache extent of the scroll view.
+  ///
+  /// See [ScrollView.scrollCacheExtent].
+  final ScrollCacheExtent? scrollCacheExtent;
 
   /// Determines the way that drag start behavior is handled.
   final DragStartBehavior dragStartBehavior;
@@ -177,7 +180,7 @@ class CenterPagingList<PageKey, Value> extends StatelessWidget {
           physics: physics,
           scrollBehavior: scrollBehavior,
           shrinkWrap: shrinkWrap,
-          cacheExtent: cacheExtent,
+          scrollCacheExtent: scrollCacheExtent,
           dragStartBehavior: dragStartBehavior,
           keyboardDismissBehavior: keyboardDismissBehavior,
           clipBehavior: clipBehavior,
@@ -195,7 +198,7 @@ class CenterPagingList<PageKey, Value> extends StatelessWidget {
           physics: physics,
           scrollBehavior: scrollBehavior,
           shrinkWrap: shrinkWrap,
-          cacheExtent: cacheExtent,
+          scrollCacheExtent: scrollCacheExtent,
           dragStartBehavior: dragStartBehavior,
           keyboardDismissBehavior: keyboardDismissBehavior,
           clipBehavior: clipBehavior,
@@ -234,7 +237,7 @@ class _CenterList<PageKey, Value> extends StatelessWidget {
     required this.physics,
     required this.scrollBehavior,
     required this.shrinkWrap,
-    required this.cacheExtent,
+    required this.scrollCacheExtent,
     required this.dragStartBehavior,
     required this.keyboardDismissBehavior,
     required this.clipBehavior,
@@ -265,7 +268,7 @@ class _CenterList<PageKey, Value> extends StatelessWidget {
   final ScrollPhysics? physics;
   final ScrollBehavior? scrollBehavior;
   final bool shrinkWrap;
-  final double? cacheExtent;
+  final ScrollCacheExtent? scrollCacheExtent;
   final DragStartBehavior dragStartBehavior;
   final ScrollViewKeyboardDismissBehavior keyboardDismissBehavior;
   final Clip clipBehavior;
@@ -294,7 +297,7 @@ class _CenterList<PageKey, Value> extends StatelessWidget {
         physics: physics,
         scrollBehavior: scrollBehavior,
         shrinkWrap: shrinkWrap,
-        cacheExtent: cacheExtent,
+        scrollCacheExtent: scrollCacheExtent,
         dragStartBehavior: dragStartBehavior,
         keyboardDismissBehavior: keyboardDismissBehavior,
         clipBehavior: clipBehavior,
@@ -317,7 +320,7 @@ class _CenterList<PageKey, Value> extends StatelessWidget {
         physics: physics,
         scrollBehavior: scrollBehavior,
         shrinkWrap: shrinkWrap,
-        cacheExtent: cacheExtent,
+        scrollCacheExtent: scrollCacheExtent,
         dragStartBehavior: dragStartBehavior,
         keyboardDismissBehavior: keyboardDismissBehavior,
         clipBehavior: clipBehavior,
@@ -342,7 +345,7 @@ class _CenterList<PageKey, Value> extends StatelessWidget {
         physics: physics,
         scrollBehavior: scrollBehavior,
         shrinkWrap: shrinkWrap,
-        cacheExtent: cacheExtent,
+        scrollCacheExtent: scrollCacheExtent,
         dragStartBehavior: dragStartBehavior,
         keyboardDismissBehavior: keyboardDismissBehavior,
         clipBehavior: clipBehavior,
@@ -367,7 +370,7 @@ class _CenterList<PageKey, Value> extends StatelessWidget {
       physics: physics,
       scrollBehavior: scrollBehavior,
       shrinkWrap: shrinkWrap,
-      cacheExtent: cacheExtent,
+      scrollCacheExtent: scrollCacheExtent,
       dragStartBehavior: dragStartBehavior,
       keyboardDismissBehavior: keyboardDismissBehavior,
       clipBehavior: clipBehavior,

--- a/lib/src/widget/grouped_paging_grid.dart
+++ b/lib/src/widget/grouped_paging_grid.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/widgets.dart';
 import 'package:paging_view/src/function.dart';
 import 'package:paging_view/src/grouped_data_source.dart';
@@ -38,7 +39,7 @@ class GroupedPagingGrid<PageKey, Parent, Value> extends StatelessWidget {
     this.physics,
     this.scrollBehavior,
     this.shrinkWrap = false,
-    this.cacheExtent,
+    this.scrollCacheExtent,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.clipBehavior = Clip.hardEdge,
@@ -153,8 +154,8 @@ class GroupedPagingGrid<PageKey, Parent, Value> extends StatelessWidget {
 
   /// The cache extent of the scroll view.
   ///
-  /// See [ScrollView.cacheExtent].
-  final double? cacheExtent;
+  /// See [ScrollView.scrollCacheExtent].
+  final ScrollCacheExtent? scrollCacheExtent;
 
   /// Determines the way that drag start behavior is handled.
   ///
@@ -182,7 +183,7 @@ class GroupedPagingGrid<PageKey, Parent, Value> extends StatelessWidget {
       physics: physics,
       scrollBehavior: scrollBehavior,
       shrinkWrap: shrinkWrap,
-      cacheExtent: cacheExtent,
+      scrollCacheExtent: scrollCacheExtent,
       dragStartBehavior: dragStartBehavior,
       keyboardDismissBehavior: keyboardDismissBehavior,
       clipBehavior: clipBehavior,

--- a/lib/src/widget/grouped_paging_list.dart
+++ b/lib/src/widget/grouped_paging_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/widgets.dart';
 import 'package:paging_view/src/function.dart';
 import 'package:paging_view/src/grouped_data_source.dart';
@@ -43,7 +44,7 @@ class GroupedPagingList<PageKey, Parent, Value> extends StatelessWidget {
     this.physics,
     this.scrollBehavior,
     this.shrinkWrap = false,
-    this.cacheExtent,
+    this.scrollCacheExtent,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.clipBehavior = Clip.hardEdge,
@@ -76,10 +77,11 @@ class GroupedPagingList<PageKey, Parent, Value> extends StatelessWidget {
     this.physics,
     this.scrollBehavior,
     this.shrinkWrap = false,
-    this.cacheExtent,
+    this.scrollCacheExtent,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.clipBehavior = Clip.hardEdge,
+    // ignore: prefer_initializing_formals
   }) : _separatorBuilder = separatorBuilder;
 
   /// The [GroupedDataSource] that provides the paginated and grouped data.
@@ -184,8 +186,8 @@ class GroupedPagingList<PageKey, Parent, Value> extends StatelessWidget {
 
   /// The cache extent of the scroll view.
   ///
-  /// See [ScrollView.cacheExtent].
-  final double? cacheExtent;
+  /// See [ScrollView.scrollCacheExtent].
+  final ScrollCacheExtent? scrollCacheExtent;
 
   /// Determines the way that drag start behavior is handled.
   ///
@@ -213,7 +215,7 @@ class GroupedPagingList<PageKey, Parent, Value> extends StatelessWidget {
       physics: physics,
       scrollBehavior: scrollBehavior,
       shrinkWrap: shrinkWrap,
-      cacheExtent: cacheExtent,
+      scrollCacheExtent: scrollCacheExtent,
       dragStartBehavior: dragStartBehavior,
       keyboardDismissBehavior: keyboardDismissBehavior,
       clipBehavior: clipBehavior,

--- a/lib/src/widget/paging_grid.dart
+++ b/lib/src/widget/paging_grid.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/widgets.dart';
 import 'package:paging_view/src/data_source.dart';
 import 'package:paging_view/src/function.dart';
@@ -37,7 +38,7 @@ class PagingGrid<PageKey, Value> extends StatelessWidget {
     this.physics,
     this.scrollBehavior,
     this.shrinkWrap = false,
-    this.cacheExtent,
+    this.scrollCacheExtent,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.clipBehavior = Clip.hardEdge,
@@ -127,8 +128,8 @@ class PagingGrid<PageKey, Value> extends StatelessWidget {
 
   /// The cache extent of the scroll view.
   ///
-  /// See [ScrollView.cacheExtent].
-  final double? cacheExtent;
+  /// See [ScrollView.scrollCacheExtent].
+  final ScrollCacheExtent? scrollCacheExtent;
 
   /// Determines the way that drag start behavior is handled.
   ///
@@ -156,7 +157,7 @@ class PagingGrid<PageKey, Value> extends StatelessWidget {
       physics: physics,
       scrollBehavior: scrollBehavior,
       shrinkWrap: shrinkWrap,
-      cacheExtent: cacheExtent,
+      scrollCacheExtent: scrollCacheExtent,
       dragStartBehavior: dragStartBehavior,
       keyboardDismissBehavior: keyboardDismissBehavior,
       clipBehavior: clipBehavior,

--- a/lib/src/widget/paging_list.dart
+++ b/lib/src/widget/paging_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/widgets.dart';
 import 'package:paging_view/src/data_source.dart';
 import 'package:paging_view/src/function.dart';
@@ -36,7 +37,7 @@ class PagingList<PageKey, Value> extends StatelessWidget {
     this.physics,
     this.scrollBehavior,
     this.shrinkWrap = false,
-    this.cacheExtent,
+    this.scrollCacheExtent,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.clipBehavior = Clip.hardEdge,
@@ -65,11 +66,12 @@ class PagingList<PageKey, Value> extends StatelessWidget {
     this.physics,
     this.scrollBehavior,
     this.shrinkWrap = false,
-    this.cacheExtent,
+    this.scrollCacheExtent,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.clipBehavior = Clip.hardEdge,
     required IndexedWidgetBuilder separatorBuilder,
+    // ignore: prefer_initializing_formals
   }) : _separatorBuilder = separatorBuilder;
 
   /// The [DataSource] that provides the paginated data.
@@ -155,8 +157,8 @@ class PagingList<PageKey, Value> extends StatelessWidget {
 
   /// The cache extent of the scroll view.
   ///
-  /// See [ScrollView.cacheExtent].
-  final double? cacheExtent;
+  /// See [ScrollView.scrollCacheExtent].
+  final ScrollCacheExtent? scrollCacheExtent;
 
   /// Determines the way that drag start behavior is handled.
   ///
@@ -184,7 +186,7 @@ class PagingList<PageKey, Value> extends StatelessWidget {
       physics: physics,
       scrollBehavior: scrollBehavior,
       shrinkWrap: shrinkWrap,
-      cacheExtent: cacheExtent,
+      scrollCacheExtent: scrollCacheExtent,
       dragStartBehavior: dragStartBehavior,
       keyboardDismissBehavior: keyboardDismissBehavior,
       clipBehavior: clipBehavior,

--- a/lib/src/widget/sliver_bounds_detector.dart
+++ b/lib/src/widget/sliver_bounds_detector.dart
@@ -40,9 +40,7 @@ class SliverBoundsDetector extends LeafRenderObjectWidget {
 /// and reports changes via the [onVisibilityChanged] callback.
 class RenderSliverBoundsDetector extends RenderSliver {
   /// Creates a render object that detects its visibility.
-  RenderSliverBoundsDetector({
-    required SliverVisibilityCallback onVisibilityChanged,
-  }) : _onVisibilityChanged = onVisibilityChanged;
+  RenderSliverBoundsDetector({required this._onVisibilityChanged});
 
   bool _isVisible = false;
 

--- a/lib/src/widget/sliver_grouped_paging_list.dart
+++ b/lib/src/widget/sliver_grouped_paging_list.dart
@@ -56,6 +56,7 @@ class SliverGroupedPagingList<PageKey, Parent, Value> extends StatelessWidget {
     this.autoLoadPrepend = true,
     this.autoLoadAppend = true,
     required IndexedWidgetBuilder separatorBuilder,
+    // ignore: prefer_initializing_formals
   }) : _separatorBuilder = separatorBuilder;
 
   /// The [GroupedDataSource] that provides the paginated and grouped data.

--- a/lib/src/widget/sliver_paging_list.dart
+++ b/lib/src/widget/sliver_paging_list.dart
@@ -47,6 +47,7 @@ class SliverPagingList<PageKey, Value> extends StatelessWidget {
     required IndexedWidgetBuilder separatorBuilder,
     this.autoLoadAppend = true,
     this.autoLoadPrepend = true,
+    // ignore: prefer_initializing_formals
   }) : _separatorBuilder = separatorBuilder;
 
   /// The [DataSource] that provides the paginated data.
@@ -172,6 +173,7 @@ class _List<PageKey, Value> extends StatelessWidget {
     required this.autoLoadPrepend,
     required this.autoLoadAppend,
     required IndexedWidgetBuilder separatorBuilder,
+    // ignore: prefer_initializing_formals
   }) : _separatorBuilder = separatorBuilder;
 
   final LoadState state;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: paging_view
 description: Like Android Jetpack's Paging library 3, manages data and displays paged lists.
-version: 2.8.1
+version: 2.9.0
 repository: https://github.com/koji-1009/paging_view
 issue_tracker: https://github.com/koji-1009/paging_view/issues
 
@@ -12,8 +12,8 @@ topics:
   - sliver
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/test/src/widget/sliver_bounds_detector_test.dart
+++ b/test/src/widget/sliver_bounds_detector_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:paging_view/src/widget/sliver_bounds_detector.dart';
 
@@ -16,7 +17,7 @@ void main() {
         home: Scaffold(
           body: CustomScrollView(
             controller: controller,
-            cacheExtent: cacheExtent,
+            scrollCacheExtent: ScrollCacheExtent.pixels(cacheExtent),
             slivers: [
               const SliverToBoxAdapter(child: SizedBox(height: sliverOffset)),
               SliverBoundsDetector(onVisibilityChanged: onVisibilityChanged),


### PR DESCRIPTION
## Summary

Prepares v2.9.0: targets Flutter 3.44+ and migrates the deprecated `cacheExtent` to `scrollCacheExtent`.

- **BREAKING**: replace `cacheExtent` (`double?`) with `scrollCacheExtent` (`ScrollCacheExtent?`) in `PagingList`, `PagingGrid`, `GroupedPagingList`, `GroupedPagingGrid`, `CenterPagingList`, following Flutter's deprecation of `ScrollView.cacheExtent` (after v3.41). Migrate `cacheExtent: 250` → `scrollCacheExtent: ScrollCacheExtent.pixels(250)`.
- Require Flutter 3.44.0 (Dart 3.12.0) or later.

## Verification

- `flutter analyze`: No issues found
- `flutter test`: 379 passed
- `dart format` / `dart run dapper`: clean
- `pana`: 160/160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
